### PR TITLE
add 2 byte field for extended advertisement event kind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bitflags"
@@ -20,6 +20,7 @@ version = "0.1.0"
 dependencies = [
  "defmt",
  "embassy-sync",
+ "embassy-time",
  "embedded-io",
  "embedded-io-async",
  "futures-intrusive",
@@ -47,9 +48,9 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "defmt"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a0ae7494d9bff013d7b89471f4c424356a71e9752e0c78abe7e6c608a16bb3"
+checksum = "3939552907426de152b3c2c6f51ed53f98f448babd26f28694c95f5906194595"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -57,22 +58,34 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8500cbe4cca056412efce4215a63d0bc20492942aeee695f23b624a53e0a6854"
+checksum = "18bdc7a7b92ac413e19e95240e75d3a73a8d8e78aa24a594c22cbb4d44b4bbda"
 dependencies = [
  "defmt-parser",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "defmt-parser"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db23d29972d99baa3de2ee2ae3f104c10564a6d05a346eb3f4c4f2c0525a06e"
+checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "embassy-sync"
@@ -85,6 +98,64 @@ dependencies = [
  "embedded-io-async",
  "futures-util",
  "heapless",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c844070d9f80dc66ee739299183312baee2e1cdeb6e90b4ea2af44f4676da5"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-time-driver",
+ "embassy-time-queue-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-util",
+ "heapless",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c214077aaa9206958b16411c157961fb7990d4ea628120a78d1a5a28aed24"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal 1.0.0",
 ]
 
 [[package]]
@@ -160,6 +231,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,10 +253,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.13"
+name = "nb"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -196,7 +288,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -213,18 +305,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -243,9 +335,19 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -253,13 +355,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.6"
+name = "thiserror"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ log = { version = "0.4", optional = true }
 embedded-io = "0.6.0"
 embedded-io-async = "0.6.0"
 embassy-sync = "0.5"
+embassy-time = "0.3"
 heapless = "0.8"
 futures-intrusive = { version = "0.5.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ log = { version = "0.4", optional = true }
 embedded-io = "0.6.0"
 embedded-io-async = "0.6.0"
 embassy-sync = "0.5"
-embassy-time = "0.3"
+embassy-time = { version = "0.3", optional = true }
 heapless = "0.8"
 futures-intrusive = { version = "0.5.0", default-features = false }

--- a/src/event.rs
+++ b/src/event.rs
@@ -115,7 +115,7 @@ events! {
     struct DisconnectionComplete(0x05) {
         status: Status,
         handle: ConnHandle,
-        reasdon: DisconnectReason,
+        reason: DisconnectReason,
     }
 
     /// Bluetooth Core Specification Vol 4, Part E, §7.7.8

--- a/src/param.rs
+++ b/src/param.rs
@@ -146,6 +146,7 @@ impl<const US: u32> Duration<US> {
     }
 }
 
+#[cfg(feature = "embassy-time")]
 impl<const US: u32> From<embassy_time::Duration> for Duration<US> {
     fn from(duration: embassy_time::Duration) -> Self {
         Self::from_micros(duration.as_micros())
@@ -214,6 +215,7 @@ impl<const US: u16> ExtDuration<US> {
     }
 }
 
+#[cfg(feature = "embassy-time")]
 impl<const US: u16> From<embassy_time::Duration> for ExtDuration<US> {
     fn from(duration: embassy_time::Duration) -> Self {
         Self::from_micros(duration.as_micros())

--- a/src/param.rs
+++ b/src/param.rs
@@ -223,6 +223,7 @@ impl<const US: u16> From<embassy_time::Duration> for ExtDuration<US> {
 param!(
     enum DisconnectReason {
         AuthenticationFailure = 0x05,
+        ConnectionTimeout = 0x08,
         RemoteUserTerminatedConn = 0x13,
         RemoteDeviceTerminatedConnLowResources = 0x14,
         RemoteDeviceTerminatedConnPowerOff = 0x15,

--- a/src/param.rs
+++ b/src/param.rs
@@ -146,6 +146,12 @@ impl<const US: u32> Duration<US> {
     }
 }
 
+impl<const US: u32> From<embassy_time::Duration> for Duration<US> {
+    fn from(duration: embassy_time::Duration) -> Self {
+        Self::from_micros(duration.as_micros())
+    }
+}
+
 /// A 24-bit isochronous duration (in microseconds)
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -205,6 +211,12 @@ impl<const US: u16> ExtDuration<US> {
     pub fn as_secs(&self) -> u32 {
         // ((1 << 24 - 1) * u16::MAX / 1_000_000) < u32::MAX so this is safe
         (self.as_micros() / 1_000_000) as u32
+    }
+}
+
+impl<const US: u16> From<embassy_time::Duration> for ExtDuration<US> {
+    fn from(duration: embassy_time::Duration) -> Self {
+        Self::from_micros(duration.as_micros())
     }
 }
 

--- a/src/param/le.rs
+++ b/src/param/le.rs
@@ -478,13 +478,47 @@ param! {
 
 param! {
     bitfield LeExtAdvEventKind[2] {
-        (0, connectable);
-        (1, scannable);
-        (2, directed);
-        (3, scan_response);
-        (4, legacy);
-        (5, data_status_1);
-        (6, data_status_2);
+        (0, connectable, set_connectable);
+        (1, scannable, set_scannable);
+        (2, directed, set_directed);
+        (3, scan_response, set_scan_response);
+        (4, legacy, set_legacy);
+        (5, data_status_1, set_data_status_1);
+        (6, data_status_2, set_data_status_2);
+    }
+}
+
+pub enum LeExtAdvDataStatus {
+    Complete,
+    IncompleteMoreExpected,
+    IncompleteTruncated,
+}
+
+impl LeExtAdvEventKind {
+    pub fn data_status(&self) -> LeExtAdvDataStatus {
+        match (self.data_status_1(), self.data_status_2()) {
+            (false, false) => LeExtAdvDataStatus::Complete,
+            (false, true) => LeExtAdvDataStatus::IncompleteMoreExpected,
+            (true, false) => LeExtAdvDataStatus::IncompleteTruncated,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn set_data_status(&mut self, status: LeExtAdvDataStatus) {
+        match status {
+            LeExtAdvDataStatus::Complete => {
+                self.set_data_status_1(false);
+                self.set_data_status_2(false);
+            }
+            LeExtAdvDataStatus::IncompleteMoreExpected => {
+                self.set_data_status_1(false);
+                self.set_data_status_2(true);
+            }
+            LeExtAdvDataStatus::IncompleteTruncated => {
+                self.set_data_status_1(true);
+                self.set_data_status_2(false);
+            }
+        }
     }
 }
 

--- a/src/param/le.rs
+++ b/src/param/le.rs
@@ -509,7 +509,7 @@ impl LeExtAdvEventKind {
             LeExtAdvDataStatus::Complete => 0,
             LeExtAdvDataStatus::IncompleteMoreExpected => 1,
             LeExtAdvDataStatus::IncompleteTruncated => 2,
-            LeExtAdvDataStatus::Reserved => 0xFF,
+            LeExtAdvDataStatus::Reserved => 3,
         };
         self.0[0] &= !(0x03 << 5);
         self.0[0] |= value << 5;

--- a/src/param/le.rs
+++ b/src/param/le.rs
@@ -490,6 +490,7 @@ pub enum LeExtAdvDataStatus {
     Complete,
     IncompleteMoreExpected,
     IncompleteTruncated,
+    Reserved,
 }
 
 impl LeExtAdvEventKind {
@@ -499,7 +500,7 @@ impl LeExtAdvEventKind {
             0 => LeExtAdvDataStatus::Complete,
             1 => LeExtAdvDataStatus::IncompleteMoreExpected,
             2 => LeExtAdvDataStatus::IncompleteTruncated,
-            _ => unreachable!(),
+            _ => LeExtAdvDataStatus::Reserved,
         }
     }
 
@@ -508,6 +509,7 @@ impl LeExtAdvEventKind {
             LeExtAdvDataStatus::Complete => 0,
             LeExtAdvDataStatus::IncompleteMoreExpected => 1,
             LeExtAdvDataStatus::IncompleteTruncated => 2,
+            LeExtAdvDataStatus::Reserved => 0xFF,
         };
         self.0[0] &= !(0x03 << 5);
         self.0[0] |= value << 5;

--- a/src/param/le.rs
+++ b/src/param/le.rs
@@ -477,6 +477,18 @@ param! {
 }
 
 param! {
+    bitfield LeExtAdvEventKind[2] {
+        (0, connectable);
+        (1, scannable);
+        (2, directed);
+        (3, scan_response);
+        (4, legacy);
+        (5, data_status_1);
+        (6, data_status_2);
+    }
+}
+
+param! {
     struct LeAdvReport<'a> {
         event_kind: LeAdvEventKind,
         addr_kind: AddrKind,
@@ -551,7 +563,7 @@ impl<'a> FusedIterator for LeAdvReportsIter<'a> {}
 
 param! {
     struct LeExtAdvReport<'a> {
-        event_kind: LeAdvEventKind,
+        event_kind: LeExtAdvEventKind,
         addr_kind: AddrKind,
         addr: BdAddr,
         data: &'a [u8],

--- a/src/param/macros.rs
+++ b/src/param/macros.rs
@@ -291,52 +291,6 @@ macro_rules! param {
             }
         }
     };
-    (
-        $(#[$attrs:meta])*
-        bitfield $name:ident[$octets:expr] {
-            $(($bit:expr, $get:ident);)+
-        }
-    ) => {
-        $(#[$attrs])*
-        #[repr(transparent)]
-        #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub struct $name([u8; $octets]);
-
-        impl $name {
-            pub fn new() -> Self {
-                Self::default()
-            }
-
-            pub fn into_inner(self) -> [u8; $octets] {
-                self.0
-            }
-
-            $(
-                pub const fn $get(&self) -> bool {
-                    const OCTET: usize = $bit / 8;
-                    const BIT: usize = $bit % 8;
-                    (self.0[OCTET] & (1 << BIT)) != 0
-                }
-            )+
-        }
-
-        unsafe impl $crate::FixedSizeValue for $name {
-            #[inline(always)]
-            fn is_valid(_data: &[u8]) -> bool {
-                true
-            }
-        }
-
-        unsafe impl $crate::ByteAlignedValue for $name {}
-
-        impl<'de> $crate::FromHciBytes<'de> for &'de $name {
-            #[inline(always)]
-            fn from_hci_bytes(data: &'de [u8]) -> Result<(Self, &'de [u8]), $crate::FromHciBytesError> {
-                <$name as $crate::ByteAlignedValue>::ref_from_hci_bytes(data)
-            }
-        }
-    };
 }
 
 macro_rules! param_slice {

--- a/src/param/macros.rs
+++ b/src/param/macros.rs
@@ -291,6 +291,52 @@ macro_rules! param {
             }
         }
     };
+    (
+        $(#[$attrs:meta])*
+        bitfield $name:ident[$octets:expr] {
+            $(($bit:expr, $get:ident);)+
+        }
+    ) => {
+        $(#[$attrs])*
+        #[repr(transparent)]
+        #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct $name([u8; $octets]);
+
+        impl $name {
+            pub fn new() -> Self {
+                Self::default()
+            }
+
+            pub fn into_inner(self) -> [u8; $octets] {
+                self.0
+            }
+
+            $(
+                pub const fn $get(&self) -> bool {
+                    const OCTET: usize = $bit / 8;
+                    const BIT: usize = $bit % 8;
+                    (self.0[OCTET] & (1 << BIT)) != 0
+                }
+            )+
+        }
+
+        unsafe impl $crate::FixedSizeValue for $name {
+            #[inline(always)]
+            fn is_valid(_data: &[u8]) -> bool {
+                true
+            }
+        }
+
+        unsafe impl $crate::ByteAlignedValue for $name {}
+
+        impl<'de> $crate::FromHciBytes<'de> for &'de $name {
+            #[inline(always)]
+            fn from_hci_bytes(data: &'de [u8]) -> Result<(Self, &'de [u8]), $crate::FromHciBytesError> {
+                <$name as $crate::ByteAlignedValue>::ref_from_hci_bytes(data)
+            }
+        }
+    };
 }
 
 macro_rules! param_slice {


### PR DESCRIPTION
The extended advertisement report has a 2 octet event kind field. One of the fields is actually a 2 bit value, which the macros don't support, hence the two fields. What's the preferred way to do that you think? I can see if I can expand the macro or maybe there is a more elegant way?