### PR TITLE
fix(le): set correct timebase for scan interval and window

### DIFF
--- a/src/cmd/le.rs
+++ b/src/cmd/le.rs
@@ -106,8 +106,8 @@ cmd! {
     LeSetScanParams(LE, 0x000b) {
         LeSetScanParamsParams {
             le_scan_kind: LeScanKind,
-            le_scan_interval: Duration<10_000>,
-            le_scan_window: Duration<10_000>,
+            le_scan_interval: Duration<625>,
+            le_scan_window: Duration<625>,
             own_addr_kind: AddrKind,
             scanning_filter_policy: ScanningFilterPolicy,
         }
@@ -130,8 +130,8 @@ cmd! {
     /// LE Create Connection command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-dc5080f3-63c3-ac48-23d1-2d35c6393ac2)
     LeCreateConn(LE, 0x000d) {
         LeCreateConnParams {
-            le_scan_interval: Duration<10_000>,
-            le_scan_window: Duration<10_000>,
+            le_scan_interval: Duration<625>,
+            le_scan_window: Duration<625>,
             use_filter_accept_list: bool,
             peer_addr_kind: AddrKind,
             peer_addr: BdAddr,


### PR DESCRIPTION
Timebase for `le_scan_interval` and `le_scan_window` is incorrect  in the code, [the specification](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-dc5080f3-63c3-ac48-23d1-2d35c6393ac2) indicates that one unit in this field means 0.625ms (`Time = N × 0.625 ms`). In this repo this was configured with a timebase of 10ms, which means `Duration`s entered as configuration would not match the behavior of the device.

A workaround before this gets merged is to multiply the value you pass by 16.