### PR TITLE
Update HCI types to Bluetooth Core Spec 6.3

### DIFF
--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -1,7 +1,7 @@
 //! Informational parameters [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-42372304-c9ef-dcab-6905-4e5b64703d45)
 
 use super::cmd;
-use crate::param::{BdAddr, CmdMask, CoreSpecificationVersion, LmpFeatureMask};
+use crate::param::{BdAddr, CmdMask, CoreSpecificationVersion, ExtendedLmpFeatures, LmpFeatureMask};
 
 cmd! {
     /// Read Local Version Information command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-cf7fef88-faa4-fd2e-7c00-ab1ec7985a19)
@@ -30,6 +30,16 @@ cmd! {
     ReadLocalSupportedFeatures(INFO_PARAMS, 0x0003) {
         Params = ();
         Return = LmpFeatureMask;
+    }
+}
+
+cmd! {
+    /// Read Local Extended Features command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-a63cc912-c71e-b53c-8b25-ee759f7b33c3)
+    ReadLocalExtendedFeatures(INFO_PARAMS, 0x0004) {
+        ReadLocalSupportedFeaturesParams {
+            page_number: u8,
+        }
+        Return = ExtendedLmpFeatures;
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -415,8 +415,6 @@ events! {
     struct ReadRemoteExtendedFeaturesComplete(0x23) {
         status: Status,
         handle: ConnHandle,
-        page_number: u8,
-        maximum_page_number: u8,
         extended_lmp_features: ExtendedLmpFeatures,
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,9 +3,9 @@
 use crate::cmd::{Opcode, SyncCmd};
 use crate::param::{
     param, AuthenticationRequirements, BdAddr, ClockOffset, ClockType, ConnHandle, ConnHandleCompletedPackets,
-    ConnectionLinkType, CoreSpecificationVersion, EncryptionEnabledLevel, Error, FlowDirection, IoCapability, KeyFlag,
-    KeypressNotificationType, LinkKeyType, LinkType, LmpFeatureMask, MaxSlots, Mode, OobDataPresent, PacketType,
-    PageScanRepetitionMode, RemainingBytes, Role, ServiceType, Status,
+    ConnectionLinkType, CoreSpecificationVersion, EncryptionEnabledLevel, Error, ExtendedLmpFeatures, FlowDirection,
+    IoCapability, KeyFlag, KeypressNotificationType, LinkKeyType, LinkType, LmpFeatureMask, MaxSlots, Mode,
+    OobDataPresent, PacketType, PageScanRepetitionMode, RemainingBytes, Role, ServiceType, Status,
 };
 use crate::{AsHciBytes, FromHciBytes, FromHciBytesError, ReadHci, ReadHciError};
 
@@ -417,7 +417,7 @@ events! {
         handle: ConnHandle,
         page_number: u8,
         maximum_page_number: u8,
-        extended_lmp_features: LmpFeatureMask,
+        extended_lmp_features: ExtendedLmpFeatures,
     }
 
     /// Synchronous Connection Complete event [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-a625aef5-c3d7-12e9-39e4-b8f3386150bb)

--- a/src/param/cmd_mask.rs
+++ b/src/param/cmd_mask.rs
@@ -1,6 +1,6 @@
 use crate::{ByteAlignedValue, FixedSizeValue, FromHciBytes};
 
-/// A command mask. [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-62/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-e2532697-4291-5379-5dd4-157ff356f0ac)
+/// A command mask. [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-e2532697-4291-5379-5dd4-157ff356f0ac)
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -233,9 +233,9 @@ cmds! {
         (2, send_keypress_notification);
         (3, io_capability_request_negative_reply);
         (4, read_encryption_key_size);
-        (5, le_cs_read_local_supported_capabilities);
+        (5, le_cs_read_local_supported_capabilities_v1);
         (6, le_cs_read_remote_supported_capabilities);
-        (7, le_cs_write_cached_remote_supported_capabilities);
+        (7, le_cs_write_cached_remote_supported_capabilities_v1);
     }
     22 => {
         (2, set_event_mask_page_2);
@@ -255,7 +255,7 @@ cmds! {
         (7, le_cs_set_default_settings);
     }
     25 => {
-        (0, le_set_event_mask);
+        (0, le_set_event_mask_v1);
         (1, le_read_buffer_size_v1);
         (2, le_read_local_supported_features);
         (4, le_set_random_addr);
@@ -492,5 +492,13 @@ cmds! {
         (5, le_connection_rate_request);
         (6, le_set_default_rate_parameters);
         (7, le_read_minimum_supported_connection_interval);
+    }
+    49 => {
+        (0, read_local_supported_commands_v2);
+        (1, le_set_event_mask_v2);
+        (2, le_cs_read_local_supported_capabilities_v2);
+        (3, le_cs_write_cached_remote_supported_capabilities_v2);
+        (4, le_cs_set_security_requirements);
+        (5, le_cs_set_default_security_requirements);
     }
 }

--- a/src/param/event_masks.rs
+++ b/src/param/event_masks.rs
@@ -1,6 +1,7 @@
 use super::param;
 
 param! {
+    /// [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-9cf88217-77b4-aeb6-61fb-d1129d48a67c)
     bitfield EventMask[8] {
         (0, is_inquiry_complete_enabled, enable_inquiry_complete);
         (1, is_inquiry_result_enabled, enable_inquiry_result);
@@ -54,6 +55,7 @@ param! {
 }
 
 param! {
+    /// [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-4e91f200-b802-45d6-9282-fd03c0dfefbe)
     bitfield EventMaskPage2[8] {
         (8, is_number_of_completed_data_blocks_enabled, enable_number_of_completed_data_blocks);
         (14, is_triggered_clock_capture_enabled, enable_triggered_clock_capture);
@@ -72,6 +74,7 @@ param! {
 }
 
 param! {
+    /// [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-8d6890a5-79b9-ba8a-2079-4efa3128263c)
     bitfield LeEventMask[8] {
         (0, is_le_conn_complete_enabled, enable_le_conn_complete);
         (1, is_le_adv_report_enabled, enable_le_adv_report);

--- a/src/param/event_masks.rs
+++ b/src/param/event_masks.rs
@@ -76,18 +76,18 @@ param! {
         (0, is_le_conn_complete_enabled, enable_le_conn_complete);
         (1, is_le_adv_report_enabled, enable_le_adv_report);
         (2, is_le_conn_update_complete_enabled, enable_le_conn_update_complete);
-        (3, is_le_read_remote_features_complete_enabled, enable_le_read_remote_features_complete);
+        (3, is_le_read_remote_features_page_0_complete_enabled, enable_le_read_remote_features_page_0_complete);
         (4, is_le_long_term_key_request_enabled, enable_le_long_term_key_request);
         (5, is_le_remote_conn_parameter_request_enabled, enable_le_remote_conn_parameter_request);
         (6, is_le_data_length_change_enabled, enable_le_data_length_change);
         (7, is_le_read_local_p256_public_key_complete_enabled, enable_le_read_local_p256_public_key_complete);
         (8, is_le_generate_dhkey_complete_enabled, enable_le_generate_dhkey_complete);
-        (9, is_le_enhanced_conn_complete_enabled, enable_le_enhanced_conn_complete);
+        (9, is_le_enhanced_conn_complete_v1_enabled, enable_le_enhanced_conn_complete_v1);
         (10, is_le_directed_adv_report_enabled, enable_le_directed_adv_report);
         (11, is_le_phy_update_complete_enabled, enable_le_phy_update_complete);
         (12, is_le_ext_adv_report_enabled, enable_le_ext_adv_report);
-        (13, is_le_periodic_adv_sync_established_enabled, enable_le_periodic_adv_sync_established);
-        (14, is_le_periodic_adv_report_enabled, enable_le_periodic_adv_report);
+        (13, is_le_periodic_adv_sync_established_v1_enabled, enable_le_periodic_adv_sync_established_v1);
+        (14, is_le_periodic_adv_report_v1_enabled, enable_le_periodic_adv_report_v1);
         (15, is_le_periodic_adv_sync_lost_enabled, enable_le_periodic_adv_sync_lost);
         (16, is_le_scan_timeout_enabled, enable_le_scan_timeout);
         (17, is_le_adv_set_terminated_enabled, enable_le_adv_set_terminated);
@@ -96,8 +96,8 @@ param! {
         (20, is_le_connectionless_iq_report_enabled, enable_le_connectionless_iq_report);
         (21, is_le_conn_iq_report_enabled, enable_le_conn_iq_report);
         (22, is_le_cte_request_failed_enabled, enable_le_cte_request_failed);
-        (23, is_le_periodic_adv_sync_transfer_received_enabled, enable_le_periodic_adv_sync_transfer_received);
-        (24, is_le_cis_established_enabled, enable_le_cis_established);
+        (23, is_le_periodic_adv_sync_transfer_received_v1_enabled, enable_le_periodic_adv_sync_transfer_received_v1);
+        (24, is_le_cis_established_v1_enabled, enable_le_cis_established_v1);
         (25, is_le_cis_request_enabled, enable_le_cis_request);
         (26, is_le_create_big_complete_enabled, enable_le_create_big_complete);
         (27, is_le_terminate_big_complete_enabled, enable_le_terminate_big_complete);
@@ -114,5 +114,20 @@ param! {
         (38, is_le_periodic_adv_subevent_data_request_enabled, enable_le_periodic_adv_subevent_data_request);
         (39, is_le_periodic_adv_response_report_enabled, enable_le_periodic_adv_response_report);
         (40, is_le_enhanced_conn_complete_v2_enabled, enable_le_enhanced_conn_complete_v2);
+        (41, is_le_cis_established_v2_enabled, enable_le_cis_established_v2);
+        (42, is_le_read_all_remote_features_complete_enabled, enable_le_read_all_remote_features_complete);
+        (43, is_le_cs_read_remote_supported_capabilities_complete_v1_enabled, enable_le_cs_read_remote_supported_capabilities_complete_v1);
+        (44, is_le_cs_read_remote_fae_table_complete_enabled, enable_le_cs_read_remote_fae_table_complete);
+        (45, is_le_cs_security_enable_complete_enabled, enable_le_cs_security_enable_complete);
+        (46, is_le_cs_config_complete_enabled, enable_le_cs_config_complete);
+        (47, is_le_cs_procedure_enable_complete_enabled, enable_le_cs_procedure_enable_complete);
+        (48, is_le_cs_subevent_result_enabled, enable_le_cs_subevent_result);
+        (49, is_le_cs_subevent_result_continue_enabled, enable_le_cs_subevent_result_continue);
+        (50, is_le_cs_test_end_complete_enabled, enable_le_cs_test_end_complete);
+        (51, is_le_monitored_advertisers_report_enabled, enable_le_monitored_advertisers_report);
+        (52, is_le_frame_space_update_complete_enabled, enable_le_frame_space_update_complete);
+        (53, is_le_utp_receive_enabled, enable_le_utp_receive);
+        (54, is_le_connection_rate_change_enabled, enable_le_connection_rate_change);
+        (55, is_le_cs_read_remote_supported_capabilities_complete_v2_enabled, enable_le_cs_read_remote_supported_capabilities_complete_v2);
     }
 }

--- a/src/param/feature_masks.rs
+++ b/src/param/feature_masks.rs
@@ -1,6 +1,7 @@
 use super::param;
 
 param! {
+    /// [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/br-edr-controller/link-manager-protocol-specification.html#UUID-c1d8d04b-edcc-8fea-a3f6-f41b520a03de)
     bitfield LmpFeatureMask[8] {
         (0, supports_3_slot_packets, set_3_slot_packets);
         (1, supports_5_slot_packets, set_5_slot_packets);
@@ -57,6 +58,32 @@ param! {
         (57, supports_variable_inquiry_tx_power_level, set_variable_inquiry_tx_power_level);
         (58, supports_enhanced_power_control, set_enhanced_power_control);
         (63, supports_ext_features, set_ext_features);
+    }
+}
+
+param! {
+    /// [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/br-edr-controller/link-manager-protocol-specification.html#UUID-c1d8d04b-edcc-8fea-a3f6-f41b520a03de)
+    bitfield LmpFeatureMaskPage1[8] {
+        (0, supports_secure_simple_pairing_host, set_secure_simple_pairing_host);
+        (1, supports_le_host, set_le_host);
+        (3, supports_secure_connections_host, set_secure_connections_host);
+    }
+}
+
+param! {
+    /// [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/br-edr-controller/link-manager-protocol-specification.html#UUID-c1d8d04b-edcc-8fea-a3f6-f41b520a03de)
+    bitfield LmpFeatureMaskPage2[8] {
+        (0, supports_connectionless_peripheral_broadcast_transmitter, set_connectionless_peripheral_broadcast_transmitter);
+        (1, supports_connectionless_peripheral_broadcast_receiver, set_connectionless_peripheral_broadcast_receiver);
+        (2, supports_synchronization_train, set_synchronization_train);
+        (3, supports_synchronization_scan, set_synchronization_scan);
+        (4, supports_hci_inquiry_response_notification_event, set_hci_inquiry_response_notification_event);
+        (5, supports_generalized_interlaced_scan, set_generalized_interlaced_scan);
+        (6, supports_coarse_clock_adjustment, set_coarse_clock_adjustment);
+        (8, supports_secure_connections_controller, set_secure_connections_controller);
+        (9, supports_ping, set_ping);
+        (10, supports_slot_availability_mask, set_slot_availability_mask);
+        (11, supports_train_nudging, set_train_nudging);
     }
 }
 

--- a/src/param/feature_masks.rs
+++ b/src/param/feature_masks.rs
@@ -1,4 +1,34 @@
 use super::param;
+use crate::FixedSizeValue;
+
+/// Extended LMP features that can be viewed as different page types.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ExtendedLmpFeatures([u8; 8]);
+
+impl ExtendedLmpFeatures {
+    /// View as page 0 LMP features.
+    pub const fn as_page_0(&self) -> &LmpFeatureMask {
+        unsafe { &*(&self.0 as *const [u8; 8] as *const LmpFeatureMask) }
+    }
+
+    /// View as page 1 LMP features.
+    pub const fn as_page_1(&self) -> &LmpFeatureMaskPage1 {
+        unsafe { &*(&self.0 as *const [u8; 8] as *const LmpFeatureMaskPage1) }
+    }
+
+    /// View as page 2 LMP features.
+    pub const fn as_page_2(&self) -> &LmpFeatureMaskPage2 {
+        unsafe { &*(&self.0 as *const [u8; 8] as *const LmpFeatureMaskPage2) }
+    }
+}
+
+unsafe impl FixedSizeValue for ExtendedLmpFeatures {
+    #[inline(always)]
+    fn is_valid(_data: &[u8]) -> bool {
+        true
+    }
+}
 
 param! {
     /// [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/br-edr-controller/link-manager-protocol-specification.html#UUID-c1d8d04b-edcc-8fea-a3f6-f41b520a03de)

--- a/src/param/feature_masks.rs
+++ b/src/param/feature_masks.rs
@@ -1,32 +1,61 @@
 use super::param;
-use crate::FixedSizeValue;
+use crate::{FixedSizeValue, FromHciBytes};
 
-/// Extended LMP features that can be viewed as different page types.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// A single page of extended LMP features.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct ExtendedLmpFeatures([u8; 8]);
+#[repr(u8)]
+pub enum LmpFeaturePage {
+    /// Page 0 of the LmpFeatureMask.
+    Page0(LmpFeatureMask),
+    /// Page 1 of the LmpFeatureMask.
+    Page1(LmpFeatureMaskPage1),
+    /// Page 2 of the LmpFeatureMask.
+    Page2(LmpFeatureMaskPage2),
+    /// An unknown page.
+    Unknown([u8; 8]),
+}
 
-impl ExtendedLmpFeatures {
-    /// View as page 0 LMP features.
-    pub const fn as_page_0(&self) -> &LmpFeatureMask {
-        unsafe { &*(&self.0 as *const [u8; 8] as *const LmpFeatureMask) }
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(C)]
+struct ExtendedLmpFeaturesRaw {
+    page_number: u8,
+    max_page_number: u8,
+    features: [u8; 8],
+}
 
-    /// View as page 1 LMP features.
-    pub const fn as_page_1(&self) -> &LmpFeatureMaskPage1 {
-        unsafe { &*(&self.0 as *const [u8; 8] as *const LmpFeatureMaskPage1) }
-    }
+/// Return parameters of the Read Local/Remote Extended Features commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(transparent)]
+pub struct ExtendedLmpFeatures(ExtendedLmpFeaturesRaw);
 
-    /// View as page 2 LMP features.
-    pub const fn as_page_2(&self) -> &LmpFeatureMaskPage2 {
-        unsafe { &*(&self.0 as *const [u8; 8] as *const LmpFeatureMaskPage2) }
+unsafe impl FixedSizeValue for ExtendedLmpFeatures {
+    fn is_valid(_data: &[u8]) -> bool {
+        true
     }
 }
 
-unsafe impl FixedSizeValue for ExtendedLmpFeatures {
-    #[inline(always)]
-    fn is_valid(_data: &[u8]) -> bool {
-        true
+impl ExtendedLmpFeatures {
+    /// Returns the feature page.
+    pub fn lmp_feature_page(&self) -> LmpFeaturePage {
+        match self.0.page_number {
+            0 => LmpFeaturePage::Page0(LmpFeatureMask::from_hci_bytes(&self.0.features).unwrap().0),
+            1 => LmpFeaturePage::Page1(LmpFeatureMaskPage1::from_hci_bytes(&self.0.features).unwrap().0),
+            2 => LmpFeaturePage::Page2(LmpFeatureMaskPage2::from_hci_bytes(&self.0.features).unwrap().0),
+            _ => LmpFeaturePage::Unknown(self.0.features),
+        }
+    }
+
+    /// Returns the maximum page number containing non-zero bits.
+    pub fn max_page_number(&self) -> u8 {
+        self.0.max_page_number
+    }
+
+    /// Returns the page number of the returned features.
+    pub fn page_number(&self) -> u8 {
+        self.0.page_number
     }
 }
 
@@ -160,7 +189,7 @@ param! {
         (38, supports_conn_subrating_host, set_conn_subrating_host);
         (39, supports_channel_classification, set_channel_classification);
         (40, supports_adv_coding_selection, set_adv_coding_selection);
-        (41, supports_adv_coding_selection_host, set_adv_coding_selection_host);
+        (41, supports_adv_coding_selection_host_support, set_adv_coding_selection_host_support);
         (43, supports_periodic_adv_with_resp_advertiser, set_periodic_adv_with_resp_advertiser);
         (44, supports_periodic_adv_with_resp_scanner, set_periodic_adv_with_resp_scanner);
         (45, supports_unsegmented_framed_mode, set_unsegmented_framed_mode);

--- a/src/param/feature_masks.rs
+++ b/src/param/feature_masks.rs
@@ -88,6 +88,7 @@ param! {
 }
 
 param! {
+    /// [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/low-energy-controller/link-layer-specification.html#UUID-56ada5ed-4ae3-acee-198f-27ead57d86f1)
     bitfield LeFeatureMask[8] {
         (0, supports_le_encryption, set_le_encryption);
         (1, supports_conn_parameters_request_procedure, set_conn_parameters_request_procedure);
@@ -129,8 +130,29 @@ param! {
         (38, supports_conn_subrating_host, set_conn_subrating_host);
         (39, supports_channel_classification, set_channel_classification);
         (40, supports_adv_coding_selection, set_adv_coding_selection);
-        (41, supports_adv_coding_selection_host_support, set_adv_coding_selection_host_support);
+        (41, supports_adv_coding_selection_host, set_adv_coding_selection_host);
         (43, supports_periodic_adv_with_resp_advertiser, set_periodic_adv_with_resp_advertiser);
         (44, supports_periodic_adv_with_resp_scanner, set_periodic_adv_with_resp_scanner);
+        (45, supports_unsegmented_framed_mode, set_unsegmented_framed_mode);
+        (46, supports_channel_sounding, set_channel_sounding);
+        (47, supports_channel_sounding_host, set_channel_sounding_host);
+        (48, supports_channel_sounding_tone_quality_indication, set_channel_sounding_tone_quality_indication);
+        (63, supports_ll_extended_feature_set, set_ll_extended_feature_set);
+    }
+}
+
+param! {
+    /// [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/low-energy-controller/link-layer-specification.html#UUID-56ada5ed-4ae3-acee-198f-27ead57d86f1)
+    bitfield LeFeatureMaskPage1[8] {
+        (0, supports_monitoring_advertisers, set_monitoring_advertisers);
+        (1, supports_frame_space_update, set_frame_space_update);
+        (2, supports_utp_ota_mode, set_utp_ota_mode);
+        (3, supports_utp_hci_mode, set_utp_hci_mode);
+        (4, ll_ota_utp_ind_max_length_bit_68, set_ll_ota_utp_ind_max_length_bit_68);
+        (5, ll_ota_utp_ind_max_length_bit_69, set_ll_ota_utp_ind_max_length_bit_69);
+        (8, supports_shorter_connection_intervals, set_shorter_connection_intervals);
+        (9, supports_shorter_connection_intervals_host, set_shorter_connection_intervals_host);
+        (10, supports_le_flushable_acl_data, set_le_flushable_acl_data);
+        (11, supports_channel_sounding_enhancement_1, set_channel_sounding_enhancement_1);
     }
 }

--- a/src/param/macros.rs
+++ b/src/param/macros.rs
@@ -40,12 +40,12 @@ macro_rules! param {
         $(#[$attrs:meta])*
         struct $name:ident($wrapped:ty)
     ) => {
+        #[doc = stringify!($name)]
         $(#[$attrs])*
         #[repr(transparent)]
         #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-        #[doc = stringify!($name)]
         pub struct $name(pub $wrapped);
 
         impl $name {
@@ -70,10 +70,10 @@ macro_rules! param {
             $(,)?
         }
     ) => {
+        #[doc = stringify!($name)]
         $(#[$attrs])*
         #[repr(C, packed)]
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-        #[doc = stringify!($name)]
         #[allow(missing_docs)]
         pub struct $name {
             $(pub $field: $ty,)*
@@ -119,10 +119,10 @@ macro_rules! param {
             $(,)?
         }
     ) => {
+        #[doc = concat!(stringify!($name), " parameter")]
         $(#[$attrs])*
         #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        #[doc = concat!(stringify!($name), " parameter")]
         #[allow(missing_docs)]
         pub struct $name$(<$life>)? {
             $(pub $field: $ty,)*
@@ -170,12 +170,12 @@ macro_rules! param {
             )+
         }
     ) => {
+        #[doc = stringify!($name)]
         $(#[$attrs])*
         #[repr(u8)]
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         #[allow(missing_docs)]
-        #[doc = stringify!($name)]
         pub enum $name {
             $(
                 $(#[$variant_attrs])*
@@ -206,11 +206,11 @@ macro_rules! param {
             $(($bit:expr, $get:ident, $set:ident);)+
         }
     ) => {
+        #[doc = stringify!($name)]
         $(#[$attrs])*
         #[repr(transparent)]
         #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        #[doc = stringify!($name)]
         pub struct $name(u8);
 
         impl $name {
@@ -259,11 +259,11 @@ macro_rules! param {
             $(($bit:expr, $get:ident, $set:ident);)+
         }
     ) => {
+        #[doc = stringify!($name)]
         $(#[$attrs])*
         #[repr(transparent)]
         #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        #[doc = stringify!($name)]
         pub struct $name([u8; $octets]);
 
         impl $name {
@@ -348,10 +348,10 @@ macro_rules! param_slice {
             $(,)?
         }
     ) => {
+        #[doc = stringify!($name)]
         $(#[$attrs])*
         #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        #[doc = stringify!($name)]
         pub struct $name([u8; $octets]);
 
         impl $name {

--- a/src/param/status.rs
+++ b/src/param/status.rs
@@ -83,7 +83,7 @@ impl From<Status> for u8 {
     }
 }
 
-/// An error representation for HCI errors.
+/// An error representation for HCI errors. [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core_v6.3/out/en/architecture,-change-history,-and-conventions/controller-error-codes.html#UUID-d9ef882f-1ac5-f85d-9a8f-0221f9c1828a)
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Error(NonZeroU8);
@@ -115,7 +115,7 @@ impl From<Error> for u8 {
     }
 }
 
-macro_rules! errnos {
+macro_rules! errors {
         (
             $(
                 ($val:expr, $konst:ident, $desc:expr);
@@ -160,7 +160,7 @@ macro_rules! errnos {
         }
     }
 
-errnos! {
+errors! {
     (0x01, UNKNOWN_CMD, "Unknown HCI Command");
     (0x02, UNKNOWN_CONN_IDENTIFIER, "Unknown Connection Identifier");
     (0x03, HARDWARE_FAILURE, "Hardware Failure");
@@ -226,4 +226,7 @@ errnos! {
     (0x43, LIMIT_REACHED, "Limit Reached");
     (0x44, OPERATION_CANCELLED_BY_HOST, "Operation Cancelled by Host");
     (0x45, PACKET_TOO_LONG, "Packet Too Long");
+    (0x46, TOO_LATE, "Too Late");
+    (0x47, TOO_EARLY, "Too Early");
+    (0x48, INSUFFICIENT_CHANNELS, "Insufficient Channels");
 }


### PR DESCRIPTION
Changes made:
- Added `LmpFeatureMaskPage1/2` and `LeFeatureMaskPage1` for extended feature pages
- Added `ExtendedLmpFeatures` struct with `as_page_0/1/2()` methods for viewing features by page
- Updated `ReadRemoteExtendedFeaturesComplete` event to use the new `ExtendedLmpFeatures` type
- Updated feature masks, event masks, command masks, and error codes to spec 6.3
- Change doc comment ordering in `param!` macro