### PR TITLE
impl packettocontroller for cmd

### DIFF
--- a/bt-hci-driver/src/lib.rs
+++ b/bt-hci-driver/src/lib.rs
@@ -21,7 +21,7 @@ pub trait PacketToHost<'d>: Sized {
 }
 
 /// An HCI packet from the host to the controller.
-pub trait PacketToController: Sized {
+pub trait PacketToController {
     /// The kind of packet this trait represents.
     const KIND: PacketKind;
 

--- a/bt-hci/src/cmd.rs
+++ b/bt-hci/src/cmd.rs
@@ -93,7 +93,7 @@ impl<E> From<param::Error> for Error<E> {
 }
 
 /// An object representing an HCI Command
-pub trait Cmd: WriteHci {
+pub trait Cmd: WriteHci + ::bt_hci_driver::PacketToController {
     /// The opcode identifying this kind of HCI Command
     const OPCODE: Opcode;
 
@@ -410,6 +410,18 @@ macro_rules! cmd {
         impl$(<$life>)? From<$params> for $name$(<$life>)? {
             fn from(params: $params) -> Self {
                 Self(params)
+            }
+        }
+
+        impl$(<$life>)? ::bt_hci_driver::PacketToController for $name$(<$life>)? {
+            const KIND: ::bt_hci_driver::PacketKind = ::bt_hci_driver::PacketKind::Cmd;
+
+            fn write_hci<W: embedded_io::Write>(&self, writer: W) -> Result<(), W::Error> {
+                <Self as $crate::WriteHci>::write_hci(self, writer)
+            }
+
+            async fn write_hci_async<W: embedded_io_async::Write>(&self, writer: W) -> Result<(), W::Error> {
+                <Self as $crate::WriteHci>::write_hci_async(self, writer).await
             }
         }
 

--- a/bt-hci/src/controller.rs
+++ b/bt-hci/src/controller.rs
@@ -46,13 +46,13 @@ pub trait Controller: ErrorType {
 }
 
 /// Marker trait for declaring that a controller supports a given HCI command.
-pub trait ControllerCmdSync<C: cmd::SyncCmd + ?Sized>: Controller {
+pub trait ControllerCmdSync<C: cmd::SyncCmd>: Controller {
     /// Note: Some implementations may require [`Controller::read()`] to be polled for this to return.
     fn exec(&self, cmd: &C) -> impl Future<Output = Result<C::Return, cmd::Error<Self::Error>>>;
 }
 
 /// Marker trait for declaring that a controller supports a given async HCI command.
-pub trait ControllerCmdAsync<C: cmd::AsyncCmd + ?Sized>: Controller {
+pub trait ControllerCmdAsync<C: cmd::AsyncCmd>: Controller {
     /// Note: Some implementations may require [`Controller::read()`] to be polled for this to return.
     fn exec(&self, cmd: &C) -> impl Future<Output = Result<(), cmd::Error<Self::Error>>>;
 }

--- a/bt-hci/src/controller.rs
+++ b/bt-hci/src/controller.rs
@@ -18,7 +18,7 @@ use futures_intrusive::sync::LocalSemaphore;
 use crate::cmd::{Cmd, CmdReturnBuf};
 use crate::event::{CommandComplete, CommandCompleteWithStatus, CommandStatus, EventKind};
 use crate::param::{RemainingBytes, Status};
-use crate::transport::{CmdPacketWrapper, Transport};
+use crate::transport::Transport;
 use crate::{cmd, data, ControllerToHostPacket, FixedSizeValue, FromHciBytes};
 
 pub mod blocking;
@@ -275,10 +275,7 @@ where
             self.slots.release_slot(idx);
         });
 
-        self.transport
-            .write(&CmdPacketWrapper(cmd))
-            .await
-            .map_err(cmd::Error::Io)?;
+        self.transport.write(cmd).await.map_err(cmd::Error::Io)?;
 
         let result = slot.wait().await;
         let return_param_bytes = RemainingBytes::from_hci_bytes_complete(&retval.as_ref()[..result.len]).unwrap();
@@ -306,10 +303,7 @@ where
             self.slots.release_slot(idx);
         });
 
-        self.transport
-            .write(&CmdPacketWrapper(cmd))
-            .await
-            .map_err(cmd::Error::Io)?;
+        self.transport.write(cmd).await.map_err(cmd::Error::Io)?;
 
         let result = slot.wait().await;
         result.status.to_result()?;

--- a/bt-hci/src/controller.rs
+++ b/bt-hci/src/controller.rs
@@ -46,13 +46,13 @@ pub trait Controller: ErrorType {
 }
 
 /// Marker trait for declaring that a controller supports a given HCI command.
-pub trait ControllerCmdSync<C: cmd::SyncCmd>: Controller {
+pub trait ControllerCmdSync<C: cmd::SyncCmd + ?Sized>: Controller {
     /// Note: Some implementations may require [`Controller::read()`] to be polled for this to return.
     fn exec(&self, cmd: &C) -> impl Future<Output = Result<C::Return, cmd::Error<Self::Error>>>;
 }
 
 /// Marker trait for declaring that a controller supports a given async HCI command.
-pub trait ControllerCmdAsync<C: cmd::AsyncCmd>: Controller {
+pub trait ControllerCmdAsync<C: cmd::AsyncCmd + ?Sized>: Controller {
     /// Note: Some implementations may require [`Controller::read()`] to be polled for this to return.
     fn exec(&self, cmd: &C) -> impl Future<Output = Result<(), cmd::Error<Self::Error>>>;
 }

--- a/bt-hci/src/transport.rs
+++ b/bt-hci/src/transport.rs
@@ -1,15 +1,11 @@
 //! HCI transport layers [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface.html)
 
-use core::future::Future;
-
 use bt_hci_driver::{PacketKind, PacketToController, PacketToHost};
 pub use bt_hci_driver::{Transport, WithIndicator};
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_sync::mutex::Mutex;
-use embedded_io::{ErrorType, ReadExactError, Write};
-use embedded_io_async::Write as AsyncWrite;
+use embedded_io::{ErrorType, ReadExactError};
 
-use crate::cmd::Cmd;
 use crate::controller::blocking::TryError;
 use crate::ReadHciError;
 
@@ -119,23 +115,6 @@ impl<M: RawMutex, R: embedded_io::Read<Error = E>, W: embedded_io::Write<Error =
         tx.write_hci(&mut *w)
             .map_err(|e| Error::Write(e))
             .map_err(TryError::Error)
-    }
-}
-
-/// Wrapper for [`Cmd`] types.
-pub struct CmdPacketWrapper<'a, T: Cmd>(pub &'a T);
-
-impl<'a, T: Cmd> PacketToController for CmdPacketWrapper<'a, T> {
-    const KIND: PacketKind = PacketKind::Cmd;
-
-    #[inline(always)]
-    fn write_hci<W: Write>(&self, writer: W) -> Result<(), W::Error> {
-        self.0.write_hci(writer)
-    }
-
-    #[inline(always)]
-    fn write_hci_async<W: AsyncWrite>(&self, writer: W) -> impl Future<Output = Result<(), W::Error>> {
-        self.0.write_hci_async(writer)
     }
 }
 


### PR DESCRIPTION
allows passing to WithIndicator without the wrapper.